### PR TITLE
handle custom user fields

### DIFF
--- a/Kernel/System/User.pm
+++ b/Kernel/System/User.pm
@@ -533,11 +533,29 @@ sub UserUpdate {
     }
 
     # set email address
-    $Self->SetPreferences(
-        UserID => $Param{UserID},
-        Key    => 'UserEmail',
-        Value  => $Param{UserEmail}
-    );
+    
+    for my $Key ( sort keys %Param ) {
+        # detect non-preferences keys
+        if ( $Key =~ m{ \A (?: UserTitle | UserFirstname | UserLastname | UserLogin | ValidID | ChangeUserID | UserID | UserPw ) }xms ) {
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'debug',
+                Message  => 'non-preference value detected: ' . $Key,
+            );
+        }
+        else {
+            # set Preferences
+            $Kernel::OM->Get('Kernel::System::Log')->Log(
+                Priority => 'debug',
+                Message  => 'preference value detected: ' . $Key
+                            . '. Value is: ' . $Param{$Key},
+            );
+            $Self->SetPreferences(
+                UserID => $Param{UserID},
+                Key    => $Key,
+                Value  => $Param{$Key}
+            );
+        }
+    }
 
     # delete cache
     $Kernel::OM->Get('Kernel::System::Cache')->CleanUp(


### PR DESCRIPTION
`GetUserData` returns user fields from both `users` and `user_preferences` tables, whereas `UserUpdate` takes unlimited range of parameters, but only updates few of them. It makes handling custom user parameters clouded. Some packages like **LDAP.pm** send all synced fields directly to `UserUpdate` method, where they are simply dropped.
The suggested patch makes deeper LDAP integration possible with just adding synced fields to **Config.pm** at `AuthSyncModule::LDAP::UserSyncMap` section like in the example shown below:
```
   $Self->{'AuthSyncModule::LDAP::UserSyncMap'} = {
          # DB -> LDAP
            UserFirstname => 'givenName',
            UserLastname  => 'sn',
            UserEmail     => 'mail',
            UserLogin   => 'sAMAccountName',
            UserSalutation => 'title',
            UserComment => 'description',
            UserPhone  => 'telephonenumber'
        };
```
Rows adding to the `users` table is no longer required. Just sync fields with LDAP and use any custom tags you need. If you are going to rely on LDAP solely, it would be the only thing you should do.
Thanks for your work